### PR TITLE
Fix poise-python depend

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ issues_url 'https://github.com/nickryand/cloudcli-cookbook/issues' if respond_to
 supports 'ubuntu'
 supports 'centos'
 
-depends 'poise-python', '>= 1.2.1', '< 2.0'
+depends 'poise-python', '~> 1.2'


### PR DESCRIPTION
chef metadata does not allow specifying multiple version constraints as [pointed out](https://github.com/nickryand/cloudcli-cookbook/pull/7#issuecomment-277178589) by @coderanger.