### PR TITLE
chef-client 12.19 fix

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -16,7 +16,7 @@ transport:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: latest
+  data_path: test/shared
 
 platforms:
   - name: ubuntu-14.04-ec2
@@ -31,3 +31,21 @@ platforms:
       image_id: <%= ENV['AWS_AMAZON_AMI'] %>
     transport:
       username: ec2-user
+
+suites:
+  - name: default
+    run_list:
+      - recipe[cloudcli::default]
+    attributes:
+      cloudcli:
+        aws:
+          version: 1.9.18
+  - name: profile_test_get
+    run_list:
+      - recipe[test_get::profile]
+      - recipe[node_dump::default]
+    attributes:
+      test_get:
+        bucket: <%= ENV['TEST_BUCKET'] %>
+        key: <%= ENV['TEST_KEY'] %>
+        checksum: <%= ENV['TEST_CHECKSUM'] %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  - name: centos-6.5
+  - name: centos-6.7
 
 suites:
   - name: default
@@ -47,4 +47,4 @@ suites:
         bucket: <%= ENV['TEST_BUCKET'] %>
         key: <%= ENV['TEST_KEY'] %>
         checksum: <%= ENV['TEST_CHECKSUM'] %>
-    excludes: ["ubuntu-14.04", "ubuntu-12.04", "centos-6.4", "centos-6.5"]
+    excludes: ["ubuntu-14.04", "ubuntu-12.04", "centos-6.4", "centos-6.7"]

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ issues_url 'https://github.com/cmlicata/cloudcli-cookbook/issues' if respond_to?
 supports 'ubuntu'
 supports 'centos'
 
-depends 'poise-python', '~> 1.2'
+depends 'poise-python', '~> 1.5'

--- a/recipes/_aws_linux.rb
+++ b/recipes/_aws_linux.rb
@@ -16,7 +16,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 #
-package 'groff'
 
 python_runtime node['cloudcli']['aws']['python']['version'] do
   provider node['cloudcli']['aws']['python']['provider']


### PR DESCRIPTION
metadata.rb - update poise-python to 1.5; works with chef client 12.19
recipes/_aws_linux.rb - remove groff package; package does not appear to be needed
.kitchen.yml - update centos-6.5 to 6.7; bento/centos-6.5 no longer available
.kitchen.ec2.yml - add default and profile_test_get suites

Used the following ami's for kitchen-ec2 tests
AWS_UBUNTU_1404_AMI=ami-49c9295f
AWS_AMAZON_AMI=ami-22ce4934