### PR TITLE
Mark credentials file template resource sensitive

### DIFF
--- a/providers/aws_credentials.rb
+++ b/providers/aws_credentials.rb
@@ -54,6 +54,7 @@ action :create do
     variables(
       :state_key => new_resource.path
     )
+    sensitive true
     action :nothing
   end
 


### PR DESCRIPTION
Inherently the credentials file will likely contain access keys that should not be logged.