### PR TITLE
Update poise-python to 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.3.0 2018-07-05
+
+* Update poise-python to 1.7
+
 ## 1.2.0 2017-04-29
 Fixes for compatibility with Chef >= 13 ([@cmlicata][])
  * Cleanup unnecessary packages for Linux installations and resources/providers

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cmlpolyglotdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure cloud provider CLI tools.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.0'
+version '1.3.0'
 source_url 'https://github.com/cmlicata/cloudcli-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/cmlicata/cloudcli-cookbook/issues' if respond_to?(:issues_url)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ issues_url 'https://github.com/cmlicata/cloudcli-cookbook/issues' if respond_to?
 supports 'ubuntu'
 supports 'centos'
 
-depends 'poise-python', '~> 1.6'
+depends 'poise-python', '~> 1.7'


### PR DESCRIPTION
Hi,

I run into #22 (https://github.com/poise/poise-python/issues/115) so I want to update `poise-python`.
Currently I am using my forked repository and it works fine so far. However I did **not** run the integration tests because the setup seems difficult to me, sorry.
Could this PR be merged?